### PR TITLE
fix style

### DIFF
--- a/infornography.rkt
+++ b/infornography.rkt
@@ -15,59 +15,63 @@
 (define (filename->string file)
   (call-with-input-file file port->string))
 
+(define (get-match pattern string)
+  (cadr (regexp-match pattern string)))
+
 (define (cpu)
   (let ((cpuinfo (filename->string "/proc/cpuinfo"))
         (pattern #px"model name\\s+:\\s+([[:print:]]+)"))
-    (cadr (regexp-match pattern cpuinfo))))
+    (get-match pattern cpuinfo)))
 
 (define (memory:make-pattern name)
   (pregexp (string-append name ":[[:space:]]+([[:digit:]]+)")))
 
 (define (memory:information)
   (let* ((mkpattern memory:make-pattern)
-         (meminfo (filename->string "/proc/meminfo"))        
-         (total  (cadr (regexp-match (mkpattern "MemTotal") meminfo)))
-         (free   (cadr (regexp-match (mkpattern "MemFree") meminfo)))
-         (cached (cadr (regexp-match (mkpattern "Cached") meminfo))))
-    
+         (meminfo (filename->string "/proc/meminfo"))
+         (get-mem-field (λ (str) (get-match (mkpattern str) meminfo)))
+         (total (get-mem-field "MemTotal"))
+         (free (get-mem-field "MemFree"))
+         (cached (get-mem-field "Cached")))
     (map (λ (num)
-           (round             
+           (round
             (/ (string->number num) 1000)))
-         `(,total ,free ,cached))))
+         (list total free cached))))
 
 (define (memory)
-  (let* ((total  (car (memory:information)))
-         (free   (cadr (memory:information)))
-         (cached (caddr (memory:information)))
-         (used  (- (- total free) cached)))
-    (let ((sforms (map number->string `(,used ,total))))
-      (string-join `(,(car sforms) "M/" ,(cadr sforms) "M") ""))))
+  (let* ((total (first (memory:information)))
+         (free (second (memory:information)))
+         (cached (third (memory:information)))
+         (used (- total free cached)))
+    (string-join (list (number->string used) "M/"
+                       (number->string total) "M")
+                 "")))
 
 (define (os)
   (string-trim (-> "uname -s")))
 
-(define data `("
-                  .......               
-              ...............           " ,($ USER) "@" ,(hostname) "
-            ....................        Shell: " ,($ SHELL) "
-          .........................     Memory: " ,(memory) "
-         ...........................    OS: " ,(os) "
-        .............................   Terminal: " ,($ TERM) "
-       ...............................  CPU: " ,(cpu) "
-       ..............x................  
-       ............xo@................  
-       ...........xoo@xxx.............  
-      ........o@oxxoo@@@@@@x..xx.....   
-       .....xo@oo...o@@@@@@x...o\\./.    
-       ....o@@@@@@@@@@@@@@@@@@@o.\\..    
-       .....x@@@@@@@@@@@o@@@@@@x/.\\.    
-        ......@@@@@@@@@@o@@@@@x....     
-        .......@@@@@@@@o@@@@o......     
-             .x@@@@@@@@@@ox.. .....     
-            .@@@@@@@ooooxxxo.   ...     
-         ...x@@@@@@@@@ooooo@... ..      
-      ........@@@@@@@....xoo........    
-   .............@@@.................... 
+(define data (list "
+                  .......
+              ...............           " ($ USER) "@" (hostname) "
+            ....................        Shell: " ($ SHELL) "
+          .........................     Memory: " (memory) "
+         ...........................    OS: " (os) "
+        .............................   Terminal: " ($ TERM) "
+       ...............................  CPU: " (cpu) "
+       ..............x................
+       ............xo@................
+       ...........xoo@xxx.............
+      ........o@oxxoo@@@@@@x..xx.....
+       .....xo@oo...o@@@@@@x...o\\./.
+       ....o@@@@@@@@@@@@@@@@@@@o.\\..
+       .....x@@@@@@@@@@@o@@@@@@x/.\\.
+        ......@@@@@@@@@@o@@@@@x....
+        .......@@@@@@@@o@@@@o......
+             .x@@@@@@@@@@ox.. .....
+            .@@@@@@@ooooxxxo.   ...
+         ...x@@@@@@@@@ooooo@... ..
+      ........@@@@@@@....xoo........
+   .............@@@....................
 ........................................
 ....................x..x................
 \n"))


### PR DESCRIPTION
- remove quasiquoting for lists, as for run-time list construction
  'list' function is most appropriate
- replace (- (- a b) c) with (- a b c), since arithmetical operators
  are of variable (potentially infinite) arity
- replace ca[d]*r functions with first, second and third, for clarily
- flatten consequitive let bindings
- abstract repeated code patterns to separate functions or lambdas
